### PR TITLE
CJS build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@metrisk/money",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metrisk/money",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A package to assist with handling monetary values",
   "main": "dist/index.js",
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,10 +3,17 @@ import typescript from 'rollup-plugin-typescript2'
 
 export default {
   input: 'src/index.ts',
-  output: {
-    file: 'dist/index.js',
-    exports: 'auto',
-  },
+  output: [
+    {
+      file: 'dist/index.js',
+      format: 'es',
+    },
+    {
+      file: 'dist/index.cjs.js',
+      format: 'cjs',
+      exports: 'auto',
+    }
+  ],
   plugins: [
     nodeResolve({ extensions: ['.js','.ts'] }),
     typescript(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { parseCurrencyString } from './Currency'
 import Money from './Money'
 
-export default {
+export {
   Money,
   parseCurrencyString,
 }


### PR DESCRIPTION
This fixes the index export as for some reason I did it as default.

A dedicated CJS build is also now added where required.