### PR TITLE
Added Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,10 +5,10 @@ jobs:
     name: Running the unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
       - name: npm cache
         id: npm-cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2.1.3
         with:
           path: node_modules
           key: npm-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
@@ -18,3 +18,14 @@ jobs:
         run: npm ci
       - name: Execute the tests
         run: npm run test
+  automerge:
+    runs-on: ubuntu-latest
+    needs: unittests
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: automerge
+        uses: pascalgn/automerge-action@v0.13.0
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_METHOD: "merge"
+          MERGE_LABELS: "dependencies"


### PR DESCRIPTION
This PR adds Dependabot config so we get automatic updates to the dependencies.

Also added an automerge step in the Action workflow, which will automatically merge the Dependabot PRs **ONLY** if the tests have passed with the updated dependency.

This addition to the work flow is simply to save time as the Dependabot PR's can be numerous and are daily (weekdays only) so it just saves having to worry about manually merging them.

Dependabot will also follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) should they be used in this repo.

I would also have added [CodeQL](https://github.com/github/codeql-action) and the [OSSAR](https://github.com/github/ossar-action) actions for further security checks but I'm not sure if they are enabled (I seem to remember they need to be approved at Org level before they'll work.)