### PR TITLE
Fixes the requirement for an approval for Dependabot PR's

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,9 +18,20 @@ jobs:
         run: npm ci
       - name: Execute the tests
         run: npm run test
-  automerge:
+  automate-pullrequest-review:
     runs-on: ubuntu-latest
     needs: unittests
+    steps:
+      - name: Approve pull request
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        uses: andrewmusgrave/automatic-pull-request-review@0.0.2
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          event: APPROVE
+          body: 'Thank you dependabot :+1:'
+  automerge:
+    runs-on: ubuntu-latest
+    needs: [unittests, automate-pullrequest-review]
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: automerge


### PR DESCRIPTION
As the title says, with the need for one approval added an action that will only auto approve when the PR is from Dependabot and also when the tests have passed.

The automerge action will only run when the tests have passed and if it has been auto approved and it's from Dependabot.

It may fail to auto approve, as the Github Token secret in an org may not be able to approve, if that is the case then just get a personal access token from @metrisk-bot, store it in Settings -> Secrets (probably useful as an Org secret) and then change line 29 to:
```yaml
repo-token: '${{ secrets.METRISK_BOT_GITHUB_TOKEN }}'
```
And it'll all work.