### PR TITLE
feat(githubpackage): update metrisk money to be a github package

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,27 +16,9 @@ jobs:
       - name: Install Deps if no cache
         if: steps.npm-cache.outputs.cache-hit != true
         run: npm ci
-      - name: Execute the tests
-        run: npm run test
-  automate-pullrequest-review:
-    runs-on: ubuntu-latest
-    needs: unittests
-    steps:
-      - name: Approve pull request
-        if: ${{ github.actor == 'dependabot[bot]' }}
-        uses: andrewmusgrave/automatic-pull-request-review@0.0.2
-        with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          event: APPROVE
-          body: 'Thank you dependabot :+1:'
-  automerge:
-    runs-on: ubuntu-latest
-    needs: [unittests, automate-pullrequest-review]
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    steps:
-      - name: automerge
-        uses: pascalgn/automerge-action@v0.13.1
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_METHOD: "merge"
-          MERGE_LABELS: "dependencies"
+      - name: Execute the tests
+        run: npm run test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         if: steps.npm-cache.outputs.cache-hit != true
         run: npm ci
         env:
-          GITHUB_TOKEN: ${{ secrets.METRISK_BOT_ACTIONS }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to GitHub packages
         run: npm publish
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
         run: npm ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build
+        run: npm run build
       - name: Publish to GitHub packages
         run: npm publish
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: On Published Release
+on:
+  push:
+    branches:
+      - feat/convert-to-github-package
+jobs:
+  publish:
+    name: Publish to GitHub packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git clone the repository
+        uses: actions/checkout@v3
+      - name: npm cache
+        id: new-cache
+        uses: actions/cache@v2.1.7
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-new-cache-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-new-cache-
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          always-auth: true
+      - name: Install Deps if no cache
+        if: steps.npm-cache.outputs.cache-hit != true
+        run: npm ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.METRISK_BOT_ACTIONS }}
+      - name: Publish to GitHub packages
+        run: npm publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: On Published Release
 on:
-  push:
-    branches:
-      - feat/convert-to-github-package
+  release:
+    types: [published]
 jobs:
   publish:
     name: Publish to GitHub packages

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+@metrisk:registry=https://npm.pkg.github.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@metrisk/money",
-  "version": "1.2.1",
+  "version": "1.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@metrisk/money",
-      "version": "1.2.1",
+      "version": "1.4.6",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.18.10",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@metrisk/money",
-  "version": "1.2.1",
+  "version": "1.4.6",
   "description": "A package to assist with handling monetary values",
   "main": "dist/index.mjs",
   "scripts": {
     "build": "rollup -c",
-    "pub": "npm publish --access public",
     "test": "jest"
   },
   "typings": "dist/index.d.ts",
@@ -31,5 +30,8 @@
   "bugs": {
     "url": "https://github.com/metrisk/money/issues"
   },
-  "homepage": "https://github.com/metrisk/money#readme"
+  "homepage": "https://github.com/metrisk/money#readme",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
 }


### PR DESCRIPTION
- Adds a local `.npmrc` to be used as a github package
- Adds an action to publish the package when a new release is published.

It's probably easier to just follow the `npm` workflow for actually bumping the package version.

So the steps should be:

- `npm version [major|minor|patch]`
- Push your changes to the branch
- Push changes to the local tag created by the version command
- Then once merged in, reference the tag created in the previous step. Once the release is published, the action created in this PR will publish the changes pushed to the tag to github packages.

We probably also want to use token generated by the metrisk bot account? As currently it's using one from mine