### PR TITLE
fix: investigated yen currency display

### DIFF
--- a/src/Money.ts
+++ b/src/Money.ts
@@ -1,18 +1,24 @@
 import { round, ROUNDING_MODES } from './Calculation'
-import { parseCurrencyString } from './Currency'
+import { getExponent, parseCurrencyString } from './Currency'
 
 import CurrencyMismatchException from './exception/CurrencyMismatchException'
 
+/**
+ * @param amount The quantity of money as an integer in the subunit of the currency (e.g. 1050 for £10.50)
+ * @param currency The alphabetic currency code as defined by ISO 4217 (e.g. GBP for Sterling)
+ * @param exponent The number of decimal places the currency supports (e.g. 2 for Sterling)
+ * @param locale The BCP 47 language tag for the locale to use when formatting (e.g. en-GB)
+ */
 export default class Money {
   private amount: number
   private currency: string
-  private precision: number
+  private exponent: number
   private locale: string
 
-  constructor(amount: number, currency: string, precision = 2) {
+  constructor(amount: number, currency: string, exponent = getExponent(currency)) {
     this.amount = amount
     this.currency = currency
-    this.precision = precision
+    this.exponent = exponent
     this.locale = undefined
   }
 
@@ -20,11 +26,11 @@ export default class Money {
     return this.toDecimal().toString()
   }
 
-  toObject(): { amount: number, currency: string, precision: number, locale: string } {
+  toObject(): { amount: number, currency: string, exponent: number, locale: string } {
     return {
       amount: this.amount,
       currency: this.currency,
-      precision: this.precision,
+      exponent: this.exponent,
       locale: this.locale || null,
     }
   }
@@ -34,12 +40,12 @@ export default class Money {
   }
 
   /**
-   * Parse monetary string value
-   * @param string input
-   * @param string currency
+   * Create a Money object from a string representation of the amount of money
+   * @param mainAmount The quantity of money as a string in the main unit of the currency (e.g. '10.50' for £10.50)
+   * @param currency The alphabetic currency code as defined by ISO 4217 (e.g. GBP for Sterling)
    */
-  static fromString(input: string, currency: string) {
-    const amount = parseCurrencyString(input, currency)
+  static fromString(mainAmount: string, currency: string): Money {
+    const amount = parseCurrencyString(mainAmount, currency)
     return new Money(amount, currency)
   }
 
@@ -60,16 +66,22 @@ export default class Money {
     return this
   }
 
+  /**
+   * @returns The amount of money in the main unit of the currency
+   */
   toDecimal(): number {
-    return this.getAmount() / Math.pow(10, this.precision)
+    return this.getAmount() / Math.pow(10, this.exponent)
   }
 
+  /**
+   * @returns A string representation of the amount of money formatted according to the locale and currency
+   */
   toLocaleString(): string {
     const options = {
       style: 'currency',
       currency: this.getCurrency(),
     }
-
+    // Note that toLocaleString() will use the locale of the calling context if none is specified
     return this.toDecimal().toLocaleString(this.getLocale(), options)
   }
 

--- a/src/Money.ts
+++ b/src/Money.ts
@@ -41,11 +41,11 @@ export default class Money {
 
   /**
    * Create a Money object from a string representation of the amount of money
-   * @param mainAmount The quantity of money as a string in the main unit of the currency (e.g. '10.50' for £10.50)
+   * @param input The quantity of money as a string in the main unit of the currency (e.g. '10.50' for £10.50)
    * @param currency The alphabetic currency code as defined by ISO 4217 (e.g. GBP for Sterling)
    */
-  static fromString(mainAmount: string, currency: string): Money {
-    const amount = parseCurrencyString(mainAmount, currency)
+  static fromString(input: string, currency: string): Money {
+    const amount = parseCurrencyString(input, currency)
     return new Money(amount, currency)
   }
 

--- a/src/__tests__/unit/Money.test.js
+++ b/src/__tests__/unit/Money.test.js
@@ -21,6 +21,11 @@ describe('Money', () => {
     expect(money.toDecimal()).toStrictEqual(21.53)
   })
 
+  it('should get the amount as a decimal with a non-two minor unit fraction', () => {
+    const money = new Money(2153, 'JPY')
+    expect(money.toDecimal()).toStrictEqual(2153)
+  })
+
   it('should get the amount as a locale formatted string', () => {
     const money = new Money(2153, 'GBP')
     expect(money.toLocaleString()).toStrictEqual('£21.53')
@@ -59,12 +64,18 @@ describe('Money', () => {
   })
 
   it('should parse a currency string and return a Money instance', () => {
-    const money = Money.fromString('22.12', 'GBP')
+    const money = Money.fromString('2200.12', 'GBP')
 
-    expect(money.getAmount()).toStrictEqual(2212)
+    expect(money.getAmount()).toStrictEqual(220012)
     expect(money.getCurrency()).toStrictEqual('GBP')
-    expect(money.toDecimal()).toStrictEqual(22.12)
-    expect(money.toLocaleString()).toStrictEqual('£22.12')
+    expect(money.toDecimal()).toStrictEqual(2200.12)
+    expect(money.toLocaleString()).toStrictEqual('£2,200.12')
+  })
+
+  it('should return non-GBP currencies with correct locale formatting', () => {
+    const money = Money.fromString(1000, 'JPY').setLocale('ja')
+
+    expect(money.toLocaleString()).toStrictEqual('￥1,000')
   })
 
   it('should return a decimal string when coerced to a string', () => {
@@ -76,7 +87,7 @@ describe('Money', () => {
   it('should return an object when coerced to an object', () => {
     const money = Money.fromString('22.12', 'GBP')
 
-    expect(money.toObject()).toStrictEqual({ amount:2212, currency: 'GBP', locale: null, precision: 2 })
+    expect(money.toObject()).toStrictEqual({ amount:2212, currency: 'GBP', locale: null, exponent: 2 })
   })
 
   it('should return the amount when coerced to json', () => {


### PR DESCRIPTION
🎟️ fixes #269

### Description

Fixes `Money` so that currencies which have other than two decimal places will be displayed correctly. Also added comments to aid precision of understanding.

### How Has This Been Tested?

Added tests which run and pass.

### Notes

I feel as though an explanation of the terms main unit and subunit could be useful for additional context, but I'm not sure it's appropriate to add even more comments. Opinions on the readability of the content of the files (esp. comments )would be much appreciated.